### PR TITLE
Add email collector chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Codex With Internet Examples
+
+This repository contains small web examples and a simple Chrome extension.
+
+## Email Collector Extension
+
+The `email_extractor_extension` directory includes a Chrome extension that
+scans pages for email addresses and stores them using `chrome.storage`.
+
+### Usage
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Choose **Load unpacked** and select the `email_extractor_extension` folder.
+4. Browse to any page. Detected email addresses will be saved automatically.
+5. Click the extension icon to view the collected emails or clear the list.
+
+### Development Notes
+- The extension uses a content script (`content.js`) to search the page text
+  for emails with a regular expression.
+- Emails are stored in `chrome.storage.local` via a background service worker.
+- The popup (`popup.html`/`popup.js`) displays saved addresses and lets you
+  clear them.
+
+

--- a/email_extractor_extension/background.js
+++ b/email_extractor_extension/background.js
@@ -1,0 +1,12 @@
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.storage.local.set({ emails: [] });
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'foundEmails' && Array.isArray(message.emails)) {
+    chrome.storage.local.get({ emails: [] }, ({ emails }) => {
+      const combined = [...new Set(emails.concat(message.emails))];
+      chrome.storage.local.set({ emails: combined });
+    });
+  }
+});

--- a/email_extractor_extension/content.js
+++ b/email_extractor_extension/content.js
@@ -1,0 +1,8 @@
+(function() {
+  const bodyText = document.body.innerText;
+  const emailRegex = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+  const found = bodyText.match(emailRegex);
+  if (found && found.length > 0) {
+    chrome.runtime.sendMessage({ type: 'foundEmails', emails: found });
+  }
+})();

--- a/email_extractor_extension/manifest.json
+++ b/email_extractor_extension/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "Email Collector",
+  "description": "Collect emails from any webpage and store them for later use.",
+  "version": "1.0",
+  "permissions": ["storage", "scripting", "activeTab"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"]
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/email_extractor_extension/popup.html
+++ b/email_extractor_extension/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Email Collector</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 10px; }
+    ul { list-style: none; padding: 0; }
+  </style>
+</head>
+<body>
+  <h1>Saved Emails</h1>
+  <ul id="emailList"></ul>
+  <button id="clear">Clear</button>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/email_extractor_extension/popup.js
+++ b/email_extractor_extension/popup.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const list = document.getElementById('emailList');
+  const clearBtn = document.getElementById('clear');
+
+  function render(emails) {
+    list.innerHTML = '';
+    if (emails.length === 0) {
+      const li = document.createElement('li');
+      li.textContent = 'No emails saved';
+      list.appendChild(li);
+    } else {
+      emails.forEach(email => {
+        const li = document.createElement('li');
+        li.textContent = email;
+        list.appendChild(li);
+      });
+    }
+  }
+
+  chrome.storage.local.get({ emails: [] }, ({ emails }) => {
+    render(emails);
+  });
+
+  clearBtn.addEventListener('click', () => {
+    chrome.storage.local.set({ emails: [] }, () => {
+      render([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- create `email_extractor_extension` with manifest, content script, background script and popup to store page emails
- document how to load and use the extension in a new README

## Testing
- `npm --version`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841f582c14c832eb5112514c01b1322